### PR TITLE
GH-44: QueryEvent close callback now queued on subscription error, in…

### DIFF
--- a/ResgateIO.Service/QueryEvent.cs
+++ b/ResgateIO.Service/QueryEvent.cs
@@ -32,7 +32,7 @@ namespace ResgateIO.Service
             catch (Exception ex)
             {
                 Service.OnError("Failed to subscribe to query event for {0}: {1}", Resource.ResourceName, ex.Message);
-                closeCallback();
+                Resource.Service.With(Resource, closeCallback);
                 return false;
             }
 

--- a/ResgateIO.Service/Router.cs
+++ b/ResgateIO.Service/Router.cs
@@ -214,8 +214,6 @@ namespace ResgateIO.Service
             /// </summary>
             public string Group { get; }
 
-            private Node node;
-
             internal Match(IAsyncHandler handler, EventHandler eventHandler, Dictionary<string, string> pathParams, string group)
             {
                 Handler = handler;


### PR DESCRIPTION
…stead of called directly.

Removed redundant node property in Router.Match.