### PR TITLE
Default to camelCase when serializing JSON.

### DIFF
--- a/ResgateIO.Service/JsonUtils.cs
+++ b/ResgateIO.Service/JsonUtils.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System.Text;
 
 namespace ResgateIO.Service
@@ -12,7 +13,16 @@ namespace ResgateIO.Service
 
         public static byte[] Serialize(object item)
         {
-            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(item));
+            DefaultContractResolver contractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
+
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(item, new JsonSerializerSettings
+            {
+                ContractResolver = contractResolver,
+                Formatting = Formatting.Indented
+            }));
         }
     }
 }

--- a/ResgateIO.Service/ResService.cs
+++ b/ResgateIO.Service/ResService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NATS.Client;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace ResgateIO.Service
 {
@@ -642,7 +643,16 @@ namespace ResgateIO.Service
             {
                 if (payload != null)
                 {
-                    string json = JsonConvert.SerializeObject(payload);
+                    DefaultContractResolver contractResolver = new DefaultContractResolver
+                    {
+                        NamingStrategy = new CamelCaseNamingStrategy()
+                    };
+
+                    string json = JsonConvert.SerializeObject(payload, new JsonSerializerSettings
+                    {
+                        ContractResolver = contractResolver,
+                        Formatting = Formatting.Indented
+                    });
                     byte[] data = Encoding.UTF8.GetBytes(json);
                     Log.Trace("<-- {0}: {1}", subject, json);
                     RawSend(subject, data);


### PR DESCRIPTION
Default JSON Serialization to camelCase to follow common JSON naming conventions without the need to clutter C# Resource classes with serialization attributes.