### PR TITLE
Feature/global error handler

### DIFF
--- a/ResgateIO.Service.UnitTests/GlobalErrorHandlerTests.cs
+++ b/ResgateIO.Service.UnitTests/GlobalErrorHandlerTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ResgateIO.Service.UnitTests
+{
+    public class GlobalErrorHandlerTests : TestsBase
+    {
+        public GlobalErrorHandlerTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [ResourcePattern("handler")]
+        class ErrorResourceHandler : BaseHandler
+        {
+            [CallMethod("action")]
+            public void Action(ICallRequest _)
+            {
+                throw new System.Exception("An error occured");
+            }
+        }
+
+        [Fact]
+        public void Usage_DefineGlobalRequestErrorHandler()
+        {
+            var expectedResult = new { code = "TestCode", message = "Test message", data = "Test data" };
+            ResService service = new ResService("error");
+
+            service.SetGlobalRequestErrorHandler((e, r) =>
+            {
+                r.Error(new ResError(expectedResult.code, expectedResult.message, expectedResult.data));
+            });
+
+            service.AddHandler(new ErrorResourceHandler());
+            service.Serve(Conn);
+            Conn.GetMsg().AssertSubject("system.reset");
+            string inbox = Conn.NATSRequest("call.error.handler.action", new RequestDto { CID = Test.CID, Params = new { value = 7 } });
+            Conn.GetMsg()
+                .AssertSubject(inbox)
+                .AssertError(expectedResult.code, expectedResult.message, expectedResult.data);
+        }
+
+        [Fact]
+        public void Usage_ExceptionInDefineGlobalRequestErrorHandler()
+        {
+            var expectedResult = new { code = "TestCode", message = "Test message", data = "Test data" };
+            ResService service = new ResService("error");
+
+            service.SetGlobalRequestErrorHandler((e, r) =>
+            {
+                throw new System.Exception("An error occured");
+            });
+
+            service.AddHandler(new ErrorResourceHandler());
+            service.Serve(Conn);
+            Conn.GetMsg().AssertSubject("system.reset");
+            string inbox = Conn.NATSRequest("call.error.handler.action", new RequestDto { CID = Test.CID, Params = new { value = 7 } });
+            Conn.GetMsg()
+                .AssertSubject(inbox)
+                .AssertError(ResError.CodeInternalError);
+        }
+
+        [Fact]
+        public void Usage_ValidateGlobalRequestErrorHandlerParameters()
+        {
+            var expectedResult = new { code = "TestCode", message = "Test message", data = "Test data" };
+            ResService service = new ResService("error");
+
+            System.Exception exceptionParam = null;
+            IRequest requestParam = null;
+            var waitForErrorCallbackExecution = new EventWaitHandle(false, EventResetMode.AutoReset);
+
+            service.SetGlobalRequestErrorHandler((e, r) =>
+            {
+                try
+                {
+                    exceptionParam = e;
+                    requestParam = r;
+                    new ResError(expectedResult.code, expectedResult.message, expectedResult.data);
+                }
+                finally { waitForErrorCallbackExecution.Set(); }
+            });
+
+            service.AddHandler(new ErrorResourceHandler());
+            service.Serve(Conn);
+            Conn.GetMsg().AssertSubject("system.reset");
+            Conn.NATSRequest("call.error.handler.action", new RequestDto { CID = Test.CID, Params = new { value = 7 } });
+
+            waitForErrorCallbackExecution.WaitOne(3000);
+
+            Assert.NotNull(exceptionParam);
+            Assert.NotNull(requestParam);
+        }
+    }
+}

--- a/ResgateIO.Service.UnitTests/ResServiceTests.cs
+++ b/ResgateIO.Service.UnitTests/ResServiceTests.cs
@@ -353,5 +353,12 @@ namespace ResgateIO.Service.UnitTests
                 .AssertSubject(inbox)
                 .AssertResult(Test.Result);
         }
+
+        [Fact]
+        public void SetErrorHandler_NullParameter_NoException()
+        {
+            Service.SetGlobalRequestErrorHandler(null);
+            Service.Serve(Conn);
+        }
     }
 }

--- a/ResgateIO.Service.UnitTests/ResgateIO.Service.UnitTests.csproj
+++ b/ResgateIO.Service.UnitTests/ResgateIO.Service.UnitTests.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NATS.Client" Version="0.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/ResgateIO.Service.sln
+++ b/ResgateIO.Service.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResgateIO.Service", "ResgateIO.Service\ResgateIO.Service.csproj", "{533C06B5-688F-4094-921E-A38396C0A821}"
 EndProject

--- a/ResgateIO.Service/ErrorHandlerDelegate.cs
+++ b/ResgateIO.Service/ErrorHandlerDelegate.cs
@@ -8,5 +8,5 @@ namespace ResgateIO.Service
     /// <param name="exception">The exception.</param>
     /// <param name="req">The executing request.</param>
     /// <returns>A RES service error</returns>
-    public delegate ResError ErrorHandlerDelegate(Exception exception, IRequest req);
+    public delegate void ErrorHandlerDelegate(Exception exception, IRequest req);
 }

--- a/ResgateIO.Service/ErrorHandlerDelegate.cs
+++ b/ResgateIO.Service/ErrorHandlerDelegate.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ResgateIO.Service
+{
+    /// <summary>
+    /// Delegate for handling global errors. The delegate is called when an unhandled exception is thrown when executing a request.
+    /// </summary>
+    /// <param name="exception">The exception.</param>
+    /// <param name="req">The executing request.</param>
+    /// <returns>A RES service error</returns>
+    public delegate ResError ErrorHandlerDelegate(Exception exception, IRequest req);
+}

--- a/ResgateIO.Service/ResService.cs
+++ b/ResgateIO.Service/ResService.cs
@@ -90,7 +90,7 @@ namespace ResgateIO.Service
         internal static readonly byte[] ResponseSuccess = Encoding.UTF8.GetBytes("{\"result\":null}");
         internal static readonly byte[] ResponseNoQueryEvents = Encoding.UTF8.GetBytes("{\"result\":{\"events\":[]}}");
 
-        internal ErrorHandlerDelegate ErrorHandler = null;
+        internal ErrorHandlerDelegate CustomRequestErrorHandler = null;
 
 
         /// <summary>
@@ -153,14 +153,24 @@ namespace ResgateIO.Service
         }
 
         /// <summary>
-        /// Sets the calling delegate which is invoked when an unhandled exception occurs during execution of a request.
+        /// Sets the delegate which is invoked when an unhandled exception occurs during execution of a request.
+        /// The caller is responsible for the request response by calling <see cref="IRequest.Error(ResError)"/> or 
+        /// any other of response types.
         /// </summary>
-        /// <param name="globalErrorHandler">The method invoked upon unhandled exception when processing request.</param>
+        /// <example>
+        /// <code>
+        ///private void GlobalErrorHandler(Exception exception, IRequest req)
+        ///{
+        /// req.Error(new ResError("Unexpected error"));
+        ///}
+        /// </code>
+        /// </example>
+        /// <param name="customErrorHandler">The method invoked upon unhandled exception when processing request.</param>
         /// <returns>The ResService instance.</returns>
-        public ResService AddGlobalRequestErrorHandler(ErrorHandlerDelegate globalErrorHandler)
+        public ResService SetGlobalRequestErrorHandler(ErrorHandlerDelegate customErrorHandler)
         {
             assertStopped();
-            this.ErrorHandler = globalErrorHandler;
+            CustomRequestErrorHandler = customErrorHandler;
             return this;
         }
 

--- a/ResgateIO.Service/ResService.cs
+++ b/ResgateIO.Service/ResService.cs
@@ -90,6 +90,8 @@ namespace ResgateIO.Service
         internal static readonly byte[] ResponseSuccess = Encoding.UTF8.GetBytes("{\"result\":null}");
         internal static readonly byte[] ResponseNoQueryEvents = Encoding.UTF8.GetBytes("{\"result\":{\"events\":[]}}");
 
+        internal ErrorHandlerDelegate ErrorHandler = null;
+
 
         /// <summary>
         /// Initializes a new instance of the ResService class without a resource name prefix.
@@ -147,6 +149,18 @@ namespace ResgateIO.Service
         {
             assertStopped();
             Log = logger ?? new VoidLogger();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the calling delegate which is invoked when an unhandled exception occurs during execution of a request.
+        /// </summary>
+        /// <param name="globalErrorHandler">The method invoked upon unhandled exception when processing request.</param>
+        /// <returns>The ResService instance.</returns>
+        public ResService AddGlobalRequestErrorHandler(ErrorHandlerDelegate globalErrorHandler)
+        {
+            assertStopped();
+            this.ErrorHandler = globalErrorHandler;
             return this;
         }
 

--- a/ResgateIO.Service/ResgateIO.Service.csproj
+++ b/ResgateIO.Service/ResgateIO.Service.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net481</TargetFrameworks>
     <PackageId>ResgateIO.Service</PackageId>
     <Version>0.5</Version>
     <Title>RES Service .NET library</Title>

--- a/ResgateIO.Service/ResgateIO.Service.csproj
+++ b/ResgateIO.Service/ResgateIO.Service.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <PackageId>ResgateIO.Service</PackageId>
-    <Version>0.4.8</Version>
+    <Version>0.5</Version>
     <Title>RES Service .NET library</Title>
     <Authors>Samuel Jirenius</Authors>
     <Owners>Samuel Jirenius</Owners>
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="NATS.Client" Version="0.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <None Include="images\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/ResgateIO.Service/request/Request.cs
+++ b/ResgateIO.Service/request/Request.cs
@@ -438,7 +438,21 @@ namespace ResgateIO.Service
             {
                 if (!replied)
                 {
-                    Error(new ResError(ex));
+                    if (Service.ErrorHandler != null)
+                    {
+                        try
+                        {
+                            Error(Service.ErrorHandler(ex, this));
+                        }
+                        catch (Exception)
+                        {
+                            Error(new ResError(ex));
+                        }
+                    }
+                    else
+                    {
+                        Error(new ResError(ex));
+                    }
                 }
 
                 // Write to log as only ResExceptions are considered valid behaviour.

--- a/ResgateIO.Service/request/Request.cs
+++ b/ResgateIO.Service/request/Request.cs
@@ -438,11 +438,12 @@ namespace ResgateIO.Service
             {
                 if (!replied)
                 {
-                    if (Service.ErrorHandler != null)
+                    if (Service.CustomRequestErrorHandler != null)
                     {
                         try
                         {
-                            Error(Service.ErrorHandler(ex, this));
+                            Service.CustomRequestErrorHandler(ex, this);
+                            return;
                         }
                         catch (Exception)
                         {


### PR DESCRIPTION
### Introducing custom global error handler
Allowing the clients to provide their own custom error handler in case of unhandled exception in a handler.

This client call to the `ResService.SetGlobalRequestErrorHandler` with a method which will be invoked in case of unhandled exception in the request handler.
The request object that caused the exception and the exception is available as parameters to the error handler method.

The client is responsible to set result to the request object as illustrated in the example below:

```csharp
 private static void GlobalErrorHandler(Exception exception, IRequest req)
 {
        if (exception is NotImplementedException)
        {
            req.NotFound();
        } 
        else
       {
            req.Error(new ResError(exception.Message));
       }
    }
}
```

#### Other changes
- Update to .NET framework 4.8.1
- Update to Newtonsoft.Json 13.0.3
- Update library version to 0.5
- Update to xunit 2.4.2
- Update to xunit.runner.visualstudio 2.4.5